### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 advent of code (i dont even kno what an advent is lol)
 so ill just post my solutions here (in python)
 python good java bad cpp bad(well its ok actually)
+[![Run on Repl.it](https://repl.it/badge/github/SansPapyrus683/green-new-deal-heckers)](https://repl.it/github/SansPapyrus683/green-new-deal-heckers)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@KevinSheng/green-new-deal-heckers).